### PR TITLE
FIX version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,17 @@ build-helm-package:
 push-helm-package:
 	helm push /tmp/starlight-proxy-chart-$(VERSION).tgz oci://ghcr.io/mc256/starlight/
 
+.PHONY: change-version-number
+change-version-number:
+	sed -i 's/var Version = "0.0.0"/var Version = "$(VERSIONNUMBER)-$(COMPILEDATE)"/g' ./util/version.go
+
 .PHONY: generate-changelog
 generate-changelog: 
 	mkdir -p ./sandbox/starlight-snapshotter-$(VERSIONNUMBER)-$(COMPILEDATE)/debian/ 2>/dev/null | true
 	sh -c ./demo/deb-package/generate-changelog.sh > ./sandbox/starlight-snapshotter-$(VERSIONNUMBER)-$(COMPILEDATE)/debian/changelog
 
 .PHONY: create-deb-package
-create-deb-package: build-starlight-grpc build-ctr-starlight generate-changelog
+create-deb-package: change-version-number build-starlight-grpc build-ctr-starlight generate-changelog
 	mkdir -p ./sandbox/starlight-snapshotter-$(VERSIONNUMBER)-$(COMPILEDATE)/ 2>/dev/null | true
 	cp -r ./demo/deb-package/debian ./sandbox/starlight-snapshotter-$(VERSIONNUMBER)-$(COMPILEDATE)/
 	mkdir -p ./sandbox/starlight-snapshotter-$(VERSIONNUMBER)-$(COMPILEDATE)/debian/starlight-snapshotter/usr/bin/ 2>/dev/null | true

--- a/util/version.go
+++ b/util/version.go
@@ -20,10 +20,11 @@ package util
 
 import (
 	"fmt"
+
 	"github.com/urfave/cli/v2"
 )
 
-var Version = "0.9.0"
+var Version = "0.0.0"
 
 func VersionAction(context *cli.Context) error {
 	fmt.Printf("starlight version %s", Version)


### PR DESCRIPTION
The version number is incorrect. Set it to `0.0.0` by default.
It uses the default branch tag if the program compiles using `make create-deb-package` from the pipeline