### PR TITLE
use absolute url for the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Starlight decouples the mechanism of container provisioning from container devel
 Starlight maintains the convenient stack-of-layers structure of container images, 
 but uses a different representation when deploying them over the network.
 The development and operational pipelines remain unchanged.
-<br>[See how Starlight works ➡️](docs/starlight-workflow.md) or [read our NSDI 2022 paper](https://www.usenix.org/conference/nsdi22/presentation/chen-jun-lin).
+<br>[See how Starlight works ➡️](https://github.com/mc256/starlight/blob/master/docs/starlight-workflow.md) or [read our NSDI 2022 paper](https://www.usenix.org/conference/nsdi22/presentation/chen-jun-lin).
 
 ## Architecture
 Starlight is implemented on top of **containerd**. It it comprised of cloud and worker components.
@@ -46,7 +46,7 @@ Starlight is implemented on top of **containerd**. It it comprised of cloud and 
 
 ## Getting Started
 
-[TL;DR?](docs/newbie.md)
+[TL;DR?](https://github.com/mc256/starlight/blob/master/docs/newbie.md)
 
 Suppose you have a container on a [OCI compatible **registry**](https://github.com/distribution/distribution) that you want to deploy.
 You need to:
@@ -54,7 +54,7 @@ You need to:
 1) Set up a **Starlight proxy**, 
 ideally close to the **registry** server you are using. Configure the proxy server to point to the registry and run it.
 Starlight supports any standard registry. (It can be deployed to k8s using ***Helm***)
-<br>[Find out how to install **Starlight proxy** ➡️](docs/starlight-proxy.md) 
+<br>[Find out how to install **Starlight proxy** ➡️](https://github.com/mc256/starlight/blob/master/docs/starlight-proxy.md) 
 
 
 2) Set up the worker to be able to run Starlight. 
@@ -63,7 +63,7 @@ installing **containerd** and the **Starlight snapshotter plugin**,
 configuring containerd to use the plugin, 
 and starting the Starlight snapshotter daemon
 (you also need to tell the snapshotter the address of the proxy server).
-<br>[Find out how to install **containerd** & **Starlight snapshotter plugin** ➡️](docs/starlight-snapshotter.md)
+<br>[Find out how to install **containerd** & **Starlight snapshotter plugin** ➡️](https://github.com/mc256/starlight/blob/master/docs/starlight-snapshotter.md)
 
 
 3) Convert the container image to the **Starlight format** container image.


### PR DESCRIPTION
Some links link to the branch's copy of the readme file, which is not up-to-date.