### PR TITLE
FIX: raspberry pi and debian support

### DIFF
--- a/demo/deb-package/Dockerfile
+++ b/demo/deb-package/Dockerfile
@@ -1,5 +1,4 @@
-#FROM amd64/ubuntu:22.04
-FROM ubuntu:22.04
+FROM debian:stable
 
 WORKDIR /go/src/app
 

--- a/demo/deb-package/debian/control
+++ b/demo/deb-package/debian/control
@@ -1,5 +1,5 @@
 Source: starlight-snapshotter
-Section: unknown
+Section: devel
 Priority: optional
 Maintainer: Junlin Chen <webmaster@mc256.dev>
 Build-Depends: build-essential, dh-systemd (>= 1.5), debhelper (>=10)
@@ -8,5 +8,5 @@ Homepage: https://github.com/mc256/starlight
 
 Package: starlight-snapshotter
 Architecture: amd64
-Depends: containerd (>= 1.5.8)
+Depends: containerd (>= 1.4.13)
 Description: Starlight is an accelerator for provisioning container-based applications.


### PR DESCRIPTION
Debian does not support `zst`, that causing `unknown compression for member 'control.tar.zst'`.